### PR TITLE
Update crt version to 1.1.2

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -28,14 +28,10 @@ spec:
         description: ModRule is the Schema for the modrules API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -43,53 +39,34 @@ spec:
             description: ModRuleSpec defines the desired state of ModRule
             properties:
               match:
-                description: Match is a list of match items which consist of select
-                  queries and expected match values or regular expressions. When all
-                  match items for an object are positive, the rule is in effect.
+                description: Match is a list of match items which consist of select queries and expected match values or regular expressions. When all match items for an object are positive, the rule is in effect.
                 items:
                   description: MatchItem represents a single match query.
                   properties:
                     matchFor:
-                      description: 'MatchFor instructs how to match the results against
-                        the match... requirements. Valid values are: - "Any" - the
-                        match is considered positive if any of the results of select
-                        have a match. - "All" - the match is considered positive only
-                        if all of the results of select have a match.'
+                      description: 'MatchFor instructs how to match the results against the match... requirements. Valid values are: - "Any" - the match is considered positive if any of the results of select have a match. - "All" - the match is considered positive only if all of the results of select have a match.'
                       enum:
                       - Any
                       - All
                       type: string
                     matchRegex:
-                      description: MatchRegex specifies the regular expression to
-                        compare the result of Select by. The match is considered positive
-                        if at least one of the results of evaluating the select query
-                        yields a match when compared to value.
+                      description: MatchRegex specifies the regular expression to compare the result of Select by. The match is considered positive if at least one of the results of evaluating the select query yields a match when compared to value.
                       nullable: true
                       type: string
                     matchValue:
-                      description: MatchValue specifies the exact value to match the
-                        result of Select by. The match is considered positive if at
-                        least one of the results of evaluating the select query yields
-                        a match when compared to matchValue.
+                      description: MatchValue specifies the exact value to match the result of Select by. The match is considered positive if at least one of the results of evaluating the select query yields a match when compared to matchValue.
                       nullable: true
                       type: string
                     matchValues:
-                      description: MatchValues specifies a list of values to match
-                        the result of Select by. The match is considered positive
-                        if at least one of the results of evaluating the select query
-                        yields a match when compared to any of the values in the array.
+                      description: MatchValues specifies a list of values to match the result of Select by. The match is considered positive if at least one of the results of evaluating the select query yields a match when compared to any of the values in the array.
                       items:
                         type: string
                       type: array
                     negate:
-                      description: Negate indicates whether the match result should
-                        be to inverted. Defaults to false.
+                      description: Negate indicates whether the match result should be to inverted. Defaults to false.
                       type: boolean
                     select:
-                      description: 'Select is a JSONPath query expression: https://goessner.net/articles/JsonPath/
-                        which yields zero or more values. If no match value or regex
-                        is specified, if the query yields a non-empty result, the
-                        match is considered positive.'
+                      description: 'Select is a JSONPath query expression: https://goessner.net/articles/JsonPath/ which yields zero or more values. If no match value or regex is specified, if the query yields a non-empty result, the match is considered positive.'
                       type: string
                   required:
                   - select
@@ -97,17 +74,12 @@ spec:
                 minItems: 1
                 type: array
               patch:
-                description: Patch is a list of patch operations to perform on the
-                  matching resources at the time of creation. The value part of a
-                  patch operation can be a golang template which accepts the resource
-                  as its context. This field must be provided for ModRules of type
-                  "patch"
+                description: Patch is a list of patch operations to perform on the matching resources at the time of creation. The value part of a patch operation can be a golang template which accepts the resource as its context. This field must be provided for ModRules of type "patch"
                 items:
                   description: PatchOperation represents a single JSON Patch operation.
                   properties:
                     op:
-                      description: Operation is the type of JSON Path operation to
-                        perform against the target element.
+                      description: Operation is the type of JSON Path operation to perform against the target element.
                       enum:
                       - add
                       - replace
@@ -117,30 +89,10 @@ spec:
                       description: Path is the JSON path to the target element.
                       type: string
                     select:
-                      description: 'Optional JSONPath query expression: https://goessner.net/articles/JsonPath/
-                        used to construct path. A patch operation is created for each
-                        result of the query. A placeholder is created for each wildcard
-                        and filter in the expression. These placeholders can be used
-                        when constructing "path". For example, if select is "$.spec.containers[*].ports[?@.containerPort
-                        == 80]" placeholder #0 will point to the index of "containers"
-                        and #1 will point to the index of "ports". This allows us
-                        to define paths such as "/spec/template/spec/containers/#0/securityContext"'
+                      description: 'Optional JSONPath query expression: https://goessner.net/articles/JsonPath/ used to construct path. A patch operation is created for each result of the query. A placeholder is created for each wildcard and filter in the expression. These placeholders can be used when constructing "path". For example, if select is "$.spec.containers[*].ports[?@.containerPort == 80]" placeholder #0 will point to the index of "containers" and #1 will point to the index of "ports". This allows us to define paths such as "/spec/template/spec/containers/#0/securityContext"'
                       type: string
                     value:
-                      description: 'Value is the JSON representation of the modification.
-                        The value is a golang template which is evaluated against
-                        the context of the target resource. KubeMod performs some
-                        analysis of the result of the template evaluation in order
-                        to infer its JSON type: - If the value matches the format
-                        of a JavaScript number, it is considered to be a number. -
-                        If the value matches a boolean literal (true/false), it is
-                        considered to be a boolean literal. - If the value matches
-                        ''null'', it is considered to be null. - If the value is surrounded
-                        by double-quotes, it is considered to be a string. - If the
-                        value is surrounded by brackets, it is considered to be a
-                        JSON array. - If the value is surrounded by curly braces,
-                        it is considered to be a JSON object. - If none of the above
-                        is true, the value is considered to be a string.'
+                      description: 'Value is the JSON representation of the modification. The value is a golang template which is evaluated against the context of the target resource. KubeMod performs some analysis of the result of the template evaluation in order to infer its JSON type: - If the value matches the format of a JavaScript number, it is considered to be a number. - If the value matches a boolean literal (true/false), it is considered to be a boolean literal. - If the value matches ''null'', it is considered to be null. - If the value is surrounded by double-quotes, it is considered to be a string. - If the value is surrounded by brackets, it is considered to be a JSON array. - If the value is surrounded by curly braces, it is considered to be a JSON object. - If none of the above is true, the value is considered to be a string.'
                       nullable: true
                       type: string
                   required:
@@ -149,20 +101,13 @@ spec:
                   type: object
                 type: array
               rejectMessage:
-                description: RejectMessage is an optional message displayed when a
-                  resource is rejected by a Reject ModRule. The field is a Golang
-                  template evaluated in the context of the object being rejected.
+                description: RejectMessage is an optional message displayed when a resource is rejected by a Reject ModRule. The field is a Golang template evaluated in the context of the object being rejected.
                 type: string
               targetNamespaceRegex:
-                description: TargetNamespaceRegex is optional and only applies to
-                  ModRules in "kubemod-system" namespace. Its usage enables cluster-wide
-                  matching of namespaced resources.
+                description: TargetNamespaceRegex is optional and only applies to ModRules in "kubemod-system" namespace. Its usage enables cluster-wide matching of namespaced resources.
                 type: string
               type:
-                description: 'Type describes the type of a ModRule. Valid values are:
-                  - "Patch" - the rule performs modifications on all the matching
-                  resources as they are created. - "Reject" - the rule rejects the
-                  creation of all matching resources.'
+                description: 'Type describes the type of a ModRule. Valid values are: - "Patch" - the rule performs modifications on all the matching resources as they are created. - "Reject" - the rule rejects the creation of all matching resources.'
                 enum:
                 - Patch
                 - Reject
@@ -348,16 +293,13 @@ spec:
         - /kubemod
         - -operator
         - -webapp
-        image: kubemod/kubemod:latest
+        image: kubemod/kubemod:v0.13.0
         livenessProbe:
           httpGet:
             path: /healthz
             port: 8083
         name: manager
         ports:
-        - containerPort: 9443
-          name: webhook-server
-          protocol: TCP
         - containerPort: 8081
           name: api
           protocol: TCP
@@ -366,6 +308,9 @@ spec:
           protocol: TCP
         - containerPort: 8083
           name: health
+          protocol: TCP
+        - containerPort: 9443
+          name: webhook-server
           protocol: TCP
         readinessProbe:
           httpGet:
@@ -404,7 +349,7 @@ spec:
         - /bin/sh
         - -c
         - ./cert-renew.sh
-        image: kubemod/kubemod-crt:v1.1.2
+        image: kubemod/kubemod-crt:v1.1.0
         name: kubemod-crt
       restartPolicy: Never
 ---

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -28,10 +28,14 @@ spec:
         description: ModRule is the Schema for the modrules API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -39,34 +43,53 @@ spec:
             description: ModRuleSpec defines the desired state of ModRule
             properties:
               match:
-                description: Match is a list of match items which consist of select queries and expected match values or regular expressions. When all match items for an object are positive, the rule is in effect.
+                description: Match is a list of match items which consist of select
+                  queries and expected match values or regular expressions. When all
+                  match items for an object are positive, the rule is in effect.
                 items:
                   description: MatchItem represents a single match query.
                   properties:
                     matchFor:
-                      description: 'MatchFor instructs how to match the results against the match... requirements. Valid values are: - "Any" - the match is considered positive if any of the results of select have a match. - "All" - the match is considered positive only if all of the results of select have a match.'
+                      description: 'MatchFor instructs how to match the results against
+                        the match... requirements. Valid values are: - "Any" - the
+                        match is considered positive if any of the results of select
+                        have a match. - "All" - the match is considered positive only
+                        if all of the results of select have a match.'
                       enum:
                       - Any
                       - All
                       type: string
                     matchRegex:
-                      description: MatchRegex specifies the regular expression to compare the result of Select by. The match is considered positive if at least one of the results of evaluating the select query yields a match when compared to value.
+                      description: MatchRegex specifies the regular expression to
+                        compare the result of Select by. The match is considered positive
+                        if at least one of the results of evaluating the select query
+                        yields a match when compared to value.
                       nullable: true
                       type: string
                     matchValue:
-                      description: MatchValue specifies the exact value to match the result of Select by. The match is considered positive if at least one of the results of evaluating the select query yields a match when compared to matchValue.
+                      description: MatchValue specifies the exact value to match the
+                        result of Select by. The match is considered positive if at
+                        least one of the results of evaluating the select query yields
+                        a match when compared to matchValue.
                       nullable: true
                       type: string
                     matchValues:
-                      description: MatchValues specifies a list of values to match the result of Select by. The match is considered positive if at least one of the results of evaluating the select query yields a match when compared to any of the values in the array.
+                      description: MatchValues specifies a list of values to match
+                        the result of Select by. The match is considered positive
+                        if at least one of the results of evaluating the select query
+                        yields a match when compared to any of the values in the array.
                       items:
                         type: string
                       type: array
                     negate:
-                      description: Negate indicates whether the match result should be to inverted. Defaults to false.
+                      description: Negate indicates whether the match result should
+                        be to inverted. Defaults to false.
                       type: boolean
                     select:
-                      description: 'Select is a JSONPath query expression: https://goessner.net/articles/JsonPath/ which yields zero or more values. If no match value or regex is specified, if the query yields a non-empty result, the match is considered positive.'
+                      description: 'Select is a JSONPath query expression: https://goessner.net/articles/JsonPath/
+                        which yields zero or more values. If no match value or regex
+                        is specified, if the query yields a non-empty result, the
+                        match is considered positive.'
                       type: string
                   required:
                   - select
@@ -74,12 +97,17 @@ spec:
                 minItems: 1
                 type: array
               patch:
-                description: Patch is a list of patch operations to perform on the matching resources at the time of creation. The value part of a patch operation can be a golang template which accepts the resource as its context. This field must be provided for ModRules of type "patch"
+                description: Patch is a list of patch operations to perform on the
+                  matching resources at the time of creation. The value part of a
+                  patch operation can be a golang template which accepts the resource
+                  as its context. This field must be provided for ModRules of type
+                  "patch"
                 items:
                   description: PatchOperation represents a single JSON Patch operation.
                   properties:
                     op:
-                      description: Operation is the type of JSON Path operation to perform against the target element.
+                      description: Operation is the type of JSON Path operation to
+                        perform against the target element.
                       enum:
                       - add
                       - replace
@@ -89,10 +117,30 @@ spec:
                       description: Path is the JSON path to the target element.
                       type: string
                     select:
-                      description: 'Optional JSONPath query expression: https://goessner.net/articles/JsonPath/ used to construct path. A patch operation is created for each result of the query. A placeholder is created for each wildcard and filter in the expression. These placeholders can be used when constructing "path". For example, if select is "$.spec.containers[*].ports[?@.containerPort == 80]" placeholder #0 will point to the index of "containers" and #1 will point to the index of "ports". This allows us to define paths such as "/spec/template/spec/containers/#0/securityContext"'
+                      description: 'Optional JSONPath query expression: https://goessner.net/articles/JsonPath/
+                        used to construct path. A patch operation is created for each
+                        result of the query. A placeholder is created for each wildcard
+                        and filter in the expression. These placeholders can be used
+                        when constructing "path". For example, if select is "$.spec.containers[*].ports[?@.containerPort
+                        == 80]" placeholder #0 will point to the index of "containers"
+                        and #1 will point to the index of "ports". This allows us
+                        to define paths such as "/spec/template/spec/containers/#0/securityContext"'
                       type: string
                     value:
-                      description: 'Value is the JSON representation of the modification. The value is a golang template which is evaluated against the context of the target resource. KubeMod performs some analysis of the result of the template evaluation in order to infer its JSON type: - If the value matches the format of a JavaScript number, it is considered to be a number. - If the value matches a boolean literal (true/false), it is considered to be a boolean literal. - If the value matches ''null'', it is considered to be null. - If the value is surrounded by double-quotes, it is considered to be a string. - If the value is surrounded by brackets, it is considered to be a JSON array. - If the value is surrounded by curly braces, it is considered to be a JSON object. - If none of the above is true, the value is considered to be a string.'
+                      description: 'Value is the JSON representation of the modification.
+                        The value is a golang template which is evaluated against
+                        the context of the target resource. KubeMod performs some
+                        analysis of the result of the template evaluation in order
+                        to infer its JSON type: - If the value matches the format
+                        of a JavaScript number, it is considered to be a number. -
+                        If the value matches a boolean literal (true/false), it is
+                        considered to be a boolean literal. - If the value matches
+                        ''null'', it is considered to be null. - If the value is surrounded
+                        by double-quotes, it is considered to be a string. - If the
+                        value is surrounded by brackets, it is considered to be a
+                        JSON array. - If the value is surrounded by curly braces,
+                        it is considered to be a JSON object. - If none of the above
+                        is true, the value is considered to be a string.'
                       nullable: true
                       type: string
                   required:
@@ -101,13 +149,20 @@ spec:
                   type: object
                 type: array
               rejectMessage:
-                description: RejectMessage is an optional message displayed when a resource is rejected by a Reject ModRule. The field is a Golang template evaluated in the context of the object being rejected.
+                description: RejectMessage is an optional message displayed when a
+                  resource is rejected by a Reject ModRule. The field is a Golang
+                  template evaluated in the context of the object being rejected.
                 type: string
               targetNamespaceRegex:
-                description: TargetNamespaceRegex is optional and only applies to ModRules in "kubemod-system" namespace. Its usage enables cluster-wide matching of namespaced resources.
+                description: TargetNamespaceRegex is optional and only applies to
+                  ModRules in "kubemod-system" namespace. Its usage enables cluster-wide
+                  matching of namespaced resources.
                 type: string
               type:
-                description: 'Type describes the type of a ModRule. Valid values are: - "Patch" - the rule performs modifications on all the matching resources as they are created. - "Reject" - the rule rejects the creation of all matching resources.'
+                description: 'Type describes the type of a ModRule. Valid values are:
+                  - "Patch" - the rule performs modifications on all the matching
+                  resources as they are created. - "Reject" - the rule rejects the
+                  creation of all matching resources.'
                 enum:
                 - Patch
                 - Reject
@@ -293,13 +348,16 @@ spec:
         - /kubemod
         - -operator
         - -webapp
-        image: kubemod/kubemod:v0.13.0
+        image: kubemod/kubemod:latest
         livenessProbe:
           httpGet:
             path: /healthz
             port: 8083
         name: manager
         ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
         - containerPort: 8081
           name: api
           protocol: TCP
@@ -308,9 +366,6 @@ spec:
           protocol: TCP
         - containerPort: 8083
           name: health
-          protocol: TCP
-        - containerPort: 9443
-          name: webhook-server
           protocol: TCP
         readinessProbe:
           httpGet:

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -349,7 +349,7 @@ spec:
         - /bin/sh
         - -c
         - ./cert-renew.sh
-        image: kubemod/kubemod-crt:v1.1.0
+        image: kubemod/kubemod-crt:v1.1.2
         name: kubemod-crt
       restartPolicy: Never
 ---

--- a/config/kubemod-crt/kubemod-crt-job.yaml
+++ b/config/kubemod-crt/kubemod-crt-job.yaml
@@ -4,12 +4,12 @@ metadata:
   name: crt-job
   namespace: system
 spec:
-  serviceAccountName: 
+  serviceAccountName:
   template:
     spec:
       containers:
       - name: kubemod-crt
-        image: kubemod/kubemod-crt:v1.1.0
+        image: kubemod/kubemod-crt:v1.1.2
         command:
         - /bin/sh
         - -c


### PR DESCRIPTION
As a followup to kubemod/kubemod-crt#6, update the version of CRT used by the bundle.

Closes #79 