### PR TITLE
fix exeuction tier - make it optional and add default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- 105: Fix breaking changes introduced with ExecutionTier
+
 ## 0.17.0 - 2022-11-06
 
 - 100: Introduce synthetic refs; inject namespace manifest into refs

--- a/api/v1beta1/modrule_types.go
+++ b/api/v1beta1/modrule_types.go
@@ -40,6 +40,8 @@ type ModRuleSpec struct {
 	// The results of executing all ModRules in a tier are passed as input to the ModRules in the next tier.
 	// This cascading execution continues until the highest tier of ModRules has been executed.
 	// ModRules in the same tier are executed in indeterminate order.
+	// +optional
+	// +kubebuilder:default=0
 	ExecutionTier int16 `json:"executionTier"`
 
 	// Match is a list of match items which consist of select queries and expected match values or regular expressions.

--- a/config/crd/bases/api.kubemod.io_modrules.yaml
+++ b/config/crd/bases/api.kubemod.io_modrules.yaml
@@ -37,6 +37,7 @@ spec:
             description: ModRuleSpec defines the desired state of ModRule
             properties:
               executionTier:
+                default: 0
                 description: ExecutionTier is a value between -32767 and 32766. ExecutionTier
                   controls when this ModRule will be executed as it relates to the
                   other ModRules loaded in the system. ModRules are matched and executed
@@ -172,7 +173,6 @@ spec:
                 - Reject
                 type: string
             required:
-            - executionTier
             - match
             - type
             type: object

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: kubemod/kubemod
-  newTag: v0.17.0
+  newTag: latest

--- a/dev-env.sh
+++ b/dev-env.sh
@@ -9,4 +9,4 @@ kubectl get secret webhook-server-cert -o=jsonpath="{.data['tls\.key']}" -n kube
 
 # Start telepresence.
 echo "Starting telepresence..."
-telepresence --swap-deployment kubemod-operator --namespace kubemod-system
+telepresence intercept kubemod-operator --namespace kubemod-system --port 9443:443


### PR DESCRIPTION
This will fix https://github.com/kubemod/kubemod/issues/105

I am not quite sure whether this should also be backported into the already released versions, would love to get some feedback here.