### PR TITLE
Implement topologySpreadConstraints and remove cpu limits

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -422,7 +422,6 @@ spec:
             port: 8083
         resources:
           limits:
-            cpu: 100m
             memory: 100Mi
           requests:
             cpu: 100m
@@ -437,6 +436,21 @@ spec:
         secret:
           defaultMode: 420
           secretName: webhook-server-cert
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: kubemod-operator
+            control-plane: controller-manager
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: kubemod-operator
+            control-plane: controller-manager
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
 ---
 apiVersion: batch/v1
 kind: CronJob

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -59,6 +59,21 @@ spec:
             cpu: 100m
             memory: 20Mi
       terminationGracePeriodSeconds: 10
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: kubemod-operator
+            control-plane: controller-manager
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: kubemod-operator
+            control-plane: controller-manager
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
cpu limits are not best practice
topologySpreadConstraints improves resiliency (replica cound needs to be increased too) 